### PR TITLE
Входные параметры startDate и endDate в цифровом формате

### DIFF
--- a/backend/fetch-data.js
+++ b/backend/fetch-data.js
@@ -99,8 +99,8 @@ function logInToZoho(login, password) {
 
 function getDataFromZoho(date, modeReport, resBody) {
 
-  var sdate = moment(date).subtract(1, 'day').startOf('month').format('DD-MMM-YYYY');
-  var edate = moment(date).subtract(1, 'day').endOf('month').format('DD-MMM-YYYY');
+  var sdate = moment(date).subtract(1, 'day').startOf('month').format('DD-MM-YYYY');
+  var edate = moment(date).subtract(1, 'day').endOf('month').format('DD-MM-YYYY');
 
   var cookies;
 


### PR DESCRIPTION
Индусы поменяли формат описания месяца с текстового на цифровой.

Раньше был вида 22-Jan-2019, теперь 22-01-2019

![1548144329063](https://user-images.githubusercontent.com/4200978/51529910-cdc28000-1e4a-11e9-8fa7-70c03326f21b.jpg)